### PR TITLE
retry attempts should be DEBUG, not INFO

### DIFF
--- a/src/python/cligraphy/core/lib/__init__.py
+++ b/src/python/cligraphy/core/lib/__init__.py
@@ -26,7 +26,7 @@ def retry(retry_count, exceptions, log_message, retry_sleep=0, backoff=1, maxdel
             try:
                 return f(*args, **kwargs)
             except (exceptions) as e:
-                logging.info('Failed to %s. Attempt: %s/%s', log_message, retry_count + 1 - _tries, retry_count)
+                logging.debug('Failed to %s. Attempt: %s/%s', log_message, retry_count + 1 - _tries, retry_count)
                 _tries -= 1
                 if _tries == 0:
                     logging.error('Failed to %s with %s attempts', log_message, retry_count)


### PR DESCRIPTION
* reporting individual failed attempts before the number of retries were
exhausted is unnecessary noise.  the attempts should only be exposed for
DEBUG logging.  If all attempts fail, that will continue to be reported
as an error.